### PR TITLE
Fix to work with Azure pipelines

### DIFF
--- a/README-nureva.md
+++ b/README-nureva.md
@@ -17,3 +17,25 @@ This is the version we will use internally. For anything that can go upstream, i
 As from the instruction in the [`cross` wiki](https://github.com/cross-rs/cross/wiki/Contributing#building-and-testing),
 just need to run `cargo build-docker-image aarch64-unknown-linux-gnu_24.04`. This builds a tagged docker image called
 `ghcr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:local`.
+
+## Publish to Nureva Azure Container Registry
+
+Since we want to share this `cross` image with the development team and build pipelines, we need to publish it when
+we have a new version. We rename the image so we can push to the Azure container registry and tag twice: for `latest`
+and the specific build date of the image, e.g. `20250311`.
+
+### Tagging
+
+```bash
+docker tag ghcr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:local nurevaromedev.azurecr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:latest
+docker tag ghcr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:local nurevaromedev.azurecr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:<build_date>
+```
+
+### Pushing
+
+```bash
+az login
+az acr login --name nurevaromedev
+docker push nurevaromedev.azurecr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:latest
+docker push nurevaromedev.azurecr.io/cross-rs/aarch64-unknown-linux-gnu_24.04:<build_date>
+```

--- a/docker/linux-image_ubuntu2404.sh
+++ b/docker/linux-image_ubuntu2404.sh
@@ -198,8 +198,11 @@ main() {
     # mv /etc/apt/sources.list /etc/apt/sources.list.bak
     # mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak
     # echo -e "${debsource}" >/etc/apt/sources.list
+    # Need to make sure the Architecture is set in ubuntu.sources so that we can pull in host architecture packages
+    # for when we need it.
+    sed -i -E "s/(Suites:.*$)/Architectures: ${dpkg_arch}\n\1/g" /etc/apt/sources.list.d/ubuntu.sources
     # archive.ubuntu.com is set by default for x86 version but arm64 is on ports.ubuntu.com so need to use that source
-    mv /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.bak
+    # as well
     cat <<'EOF' >/etc/apt/sources.list.d/ubuntu-arm64.sources
 Types: deb
 URIs: http://ports.ubuntu.com/ubuntu-ports

--- a/docker/qemu-ubuntu-nostatic.sh
+++ b/docker/qemu-ubuntu-nostatic.sh
@@ -36,6 +36,10 @@ main() {
         libselinux1-dev \
         zlib1g-dev
 
+    # We don't use install_packages for this because anything in there is removed at the end of this script but we need
+    # these to run qemu when not building as static.
+    apt-get install libglib2.0-0t64
+
     # if we have python3.6+, we can install qemu 7.0.0, which needs ninja-build
     # ubuntu 16.04 only provides python3.5, so remove when we have a newer qemu.
     is_ge_python36=$(python3 -c "import sys; print(int(sys.version_info >= (3, 6)))")


### PR DESCRIPTION
Primarily support the ability to install build tools for the host architecture. Needed for things like `protobuf-compiler`. The way we had it, it was installing tools for target architecture and couldn't execute.